### PR TITLE
Fix gradle compile errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     }
 }
 
+
 allprojects {
     version = VERSION_NAME
     group = GROUP

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -2109,7 +2109,7 @@ public class WeekView extends View {
     /**
      * set fix visible time.
      * @param startHour limit time display on top (between 0~24)
-     * @param endHour limit time display at bottom (between 0~24 and > startHour)
+     * @param endHour limit time display at bottom (between 0~24 and larger then startHour)
      * */
     public void setLimitTime(int startHour, int endHour){
         if(endHour <= startHour || startHour < 0 || endHour > 24){

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "com.alamkanak.weekview"
-        minSdkVersion 9
+        minSdkVersion 14
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Currently the `gradle build` fails with:

- an error in the javadoc 
`Android-Week-View/library/src/main/java/com/alamkanak/weekview/WeekView.java:2112: error: bad use of '>'  @param endHour limit time display at bottom (between 0~24 and > startHour)`
- a linter error in the sample because attr `android:textAllCaps` is available since sdk 14 and the minSdkVersion is at 9

I fixed the comment and incresed the minSdkVersion to 14