### PR TITLE
improve string checks for drawing event text

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -1141,14 +1141,14 @@ public class WeekView extends View {
 
         // Prepare the name of the event.
         SpannableStringBuilder bob = new SpannableStringBuilder();
-        if (event.getName() != null) {
+        if (!TextUtils.isEmpty(event.getName())) {
             bob.append(event.getName());
             bob.setSpan(new StyleSpan(android.graphics.Typeface.BOLD), 0, bob.length(), 0);
-            bob.append(' ');
         }
-
         // Prepare the location of the event.
-        if (event.getLocation() != null) {
+        if (!TextUtils.isEmpty(event.getLocation())) {
+            if (bob.length() > 0)
+                bob.append(' ');
             bob.append(event.getLocation());
         }
 


### PR DESCRIPTION
check not only null but also 0-length

append separator ' ' only when location is set
to avoid trailing space and ellipsizing with column width close to string length