### PR TITLE
Scroll NumberOfVisibleDays by NumberOfVisibleDays (inspired by #68)

### DIFF
--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -110,6 +110,11 @@ public class WeekView extends View {
     private int mScaledTouchSlop = 0;
     private EventRect mNewEventRect;
     private TextColorPicker textColorPicker;
+    private float mSizeOfWeekView;
+    private float mDistanceDone = 0;
+    private float mDistanceMin;
+    protected int mOffsetValueToSecureScreen = 9;
+    private float mStartOriginForScroll = 0;
 
     // Attributes and their default values.
     private int mHourHeight = 50;
@@ -174,6 +179,7 @@ public class WeekView extends View {
     private boolean mAutoLimitTime = false;
     private boolean mEnableDropListener = false;
     private int mMinOverlappingMinutes = 0;
+    private boolean mScrollNumberOfVisibleDays = false;
 
     // Listeners.
     private EventClickListener mEventClickListener;
@@ -190,6 +196,7 @@ public class WeekView extends View {
 
         @Override
         public boolean onDown(MotionEvent e) {
+            mStartOriginForScroll = mCurrentOrigin.x;
             goToNearestOrigin();
             return true;
         }
@@ -238,6 +245,13 @@ public class WeekView extends View {
                 case RIGHT:
                     float minX = getXMinLimit();
                     float maxX = getXMaxLimit();
+
+                    if (e2.getX() < 0) {
+                        mDistanceDone = e2.getX() - e1.getX();
+                    } else {
+                        mDistanceDone = e1.getX() - e2.getX();
+                    }
+
                     if ((mCurrentOrigin.x - (distanceX * mXScrollingSpeed)) > maxX) {
                         mCurrentOrigin.x = maxX;
                     } else if ((mCurrentOrigin.x - (distanceX * mXScrollingSpeed)) < minX) {
@@ -282,7 +296,9 @@ public class WeekView extends View {
             switch (mCurrentFlingDirection) {
                 case LEFT:
                 case RIGHT:
-                    mScroller.fling((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, (int) (velocityX * mXScrollingSpeed), 0, (int) getXMinLimit(), (int) getXMaxLimit(), (int) getYMinLimit(), (int) getYMaxLimit());
+                    if(!mScrollNumberOfVisibleDays) {
+                        mScroller.fling((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, (int) (velocityX * mXScrollingSpeed), 0, (int) getXMinLimit(), (int) getXMaxLimit(), (int) getYMinLimit(), (int) getYMaxLimit());
+                    }
                     break;
                 case VERTICAL:
                     mScroller.fling((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, 0, (int) velocityY, (int) getXMinLimit(), (int) getXMaxLimit(), (int) getYMinLimit(), (int) getYMaxLimit());
@@ -494,6 +510,7 @@ public class WeekView extends View {
             if (a.getBoolean(R.styleable.WeekView_dropListenerEnabled, false))
                 this.enableDropListener();
             mMinOverlappingMinutes = a.getInt(R.styleable.WeekView_minOverlappingMinutes, 0);
+            mScrollNumberOfVisibleDays = a.getBoolean(R.styleable.WeekView_scrollNumberOfVisibleDays, false);
         } finally {
             a.recycle();
         }
@@ -2525,6 +2542,10 @@ public class WeekView extends View {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+
+        mSizeOfWeekView = (mWidthPerDay + mColumnGap) * getNumberOfVisibleDays();
+        mDistanceMin = mSizeOfWeekView / mOffsetValueToSecureScreen;
+        
         mScaleDetector.onTouchEvent(event);
         boolean val = mGestureDetector.onTouchEvent(event);
 
@@ -2542,40 +2563,78 @@ public class WeekView extends View {
     private void goToNearestOrigin() {
         double leftDays = mCurrentOrigin.x / (mWidthPerDay + mColumnGap);
 
-        if (mCurrentFlingDirection != Direction.NONE) {
-            // snap to nearest day
-            leftDays = Math.round(leftDays);
-        } else if (mCurrentScrollDirection == Direction.LEFT) {
-            // snap to last day
-            leftDays = Math.floor(leftDays);
-        } else if (mCurrentScrollDirection == Direction.RIGHT) {
-            // snap to next day
-            leftDays = Math.ceil(leftDays);
+        float beforeScroll = mStartOriginForScroll;
+        boolean isPassed = false;
+
+        if (mDistanceDone > mDistanceMin || mDistanceDone < -mDistanceMin || !mScrollNumberOfVisibleDays) {
+
+            if (!mScrollNumberOfVisibleDays && mCurrentFlingDirection != Direction.NONE) {
+                // snap to nearest day
+                leftDays = Math.round(leftDays);
+            } else if (mCurrentScrollDirection == Direction.LEFT) {
+                // snap to last day
+                leftDays = Math.floor(leftDays);
+                mStartOriginForScroll -= mSizeOfWeekView;
+                isPassed = true;
+            } else if (mCurrentScrollDirection == Direction.RIGHT) {
+                // snap to next day
+                leftDays = Math.floor(leftDays);
+                mStartOriginForScroll += mSizeOfWeekView;
+                isPassed = true;
+            } else {
+                // snap to nearest day
+                leftDays = Math.round(leftDays);
+            }
+
+
+            if (mScrollNumberOfVisibleDays) {
+                boolean mayScrollHorizontal = beforeScroll - mStartOriginForScroll < getXMaxLimit() && mCurrentOrigin.x - mStartOriginForScroll > getXMinLimit();
+                if (isPassed && mayScrollHorizontal) {
+                    // Stop current animation.
+                    mScroller.forceFinished(true);
+                    // Snap to date.
+                    if (mCurrentScrollDirection == Direction.LEFT) {
+                        mScroller.startScroll((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, (int) ((beforeScroll - mCurrentOrigin.x) - mSizeOfWeekView), 0, 200);
+                    } else if (mCurrentScrollDirection == Direction.RIGHT) {
+                        mScroller.startScroll((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, (int) (mSizeOfWeekView - (mCurrentOrigin.x - beforeScroll)), 0, 200);
+                    }
+                    ViewCompat.postInvalidateOnAnimation(WeekView.this);
+                }
+            }
+            else{
+                int nearestOrigin = (int) (mCurrentOrigin.x - leftDays * (mWidthPerDay + mColumnGap));
+                boolean mayScrollHorizontal = mCurrentOrigin.x - nearestOrigin < getXMaxLimit() && mCurrentOrigin.x - nearestOrigin > getXMinLimit();
+                if (mayScrollHorizontal) {
+                    mScroller.startScroll((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, -nearestOrigin, 0);
+                    ViewCompat.postInvalidateOnAnimation(WeekView.this);
+                }
+
+                if (nearestOrigin != 0 && mayScrollHorizontal) {
+                    // Stop current animation.
+                    mScroller.forceFinished(true);
+                    // Snap to date.
+                    mScroller.startScroll((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, -nearestOrigin, 0, (int) (Math.abs(nearestOrigin) / mWidthPerDay * mScrollDuration));
+                    ViewCompat.postInvalidateOnAnimation(WeekView.this);
+                }
+            }
+
+            // Reset scrolling and fling direction.
+            mCurrentScrollDirection = mCurrentFlingDirection = Direction.NONE;
+
+
         } else {
-            // snap to nearest day
-            leftDays = Math.round(leftDays);
-        }
-
-        int nearestOrigin = (int) (mCurrentOrigin.x - leftDays * (mWidthPerDay + mColumnGap));
-        boolean mayScrollHorizontal = mCurrentOrigin.x - nearestOrigin < getXMaxLimit()
-                && mCurrentOrigin.x - nearestOrigin > getXMinLimit();
-
-        if (mayScrollHorizontal) {
-            mScroller.startScroll((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, -nearestOrigin, 0);
-            ViewCompat.postInvalidateOnAnimation(WeekView.this);
-        }
-
-        if (nearestOrigin != 0 && mayScrollHorizontal) {
-            // Stop current animation.
             mScroller.forceFinished(true);
-            // Snap to date.
-            mScroller.startScroll((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, -nearestOrigin, 0, (int) (Math.abs(nearestOrigin) / mWidthPerDay * mScrollDuration));
+            if (mCurrentScrollDirection == Direction.LEFT) {
+                mScroller.startScroll((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, (int) beforeScroll - (int) mCurrentOrigin.x, 0, 200);
+            } else if (mCurrentScrollDirection == Direction.RIGHT) {
+                mScroller.startScroll((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, (int) beforeScroll - (int) mCurrentOrigin.x, 0, 200);
+            }
             ViewCompat.postInvalidateOnAnimation(WeekView.this);
-        }
-        // Reset scrolling and fling direction.
-        mCurrentScrollDirection = mCurrentFlingDirection = Direction.NONE;
-    }
 
+            // Reset scrolling and fling direction.
+            mCurrentScrollDirection = mCurrentFlingDirection = Direction.NONE;
+        }
+    }
 
     @Override
     public void computeScroll() {

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -179,7 +179,7 @@ public class WeekView extends View {
     private boolean mAutoLimitTime = false;
     private boolean mEnableDropListener = false;
     private int mMinOverlappingMinutes = 0;
-    private boolean mScrollNumberOfVisibleDays = false;
+    private boolean mIsScrollNumberOfVisibleDays = false;
 
     // Listeners.
     private EventClickListener mEventClickListener;
@@ -296,7 +296,7 @@ public class WeekView extends View {
             switch (mCurrentFlingDirection) {
                 case LEFT:
                 case RIGHT:
-                    if(!mScrollNumberOfVisibleDays) {
+                    if(!mIsScrollNumberOfVisibleDays) {
                         mScroller.fling((int) mCurrentOrigin.x, (int) mCurrentOrigin.y, (int) (velocityX * mXScrollingSpeed), 0, (int) getXMinLimit(), (int) getXMaxLimit(), (int) getYMinLimit(), (int) getYMaxLimit());
                     }
                     break;
@@ -510,7 +510,7 @@ public class WeekView extends View {
             if (a.getBoolean(R.styleable.WeekView_dropListenerEnabled, false))
                 this.enableDropListener();
             mMinOverlappingMinutes = a.getInt(R.styleable.WeekView_minOverlappingMinutes, 0);
-            mScrollNumberOfVisibleDays = a.getBoolean(R.styleable.WeekView_scrollNumberOfVisibleDays, false);
+            mIsScrollNumberOfVisibleDays = a.getBoolean(R.styleable.WeekView_isScrollNumberOfVisibleDays, false);
         } finally {
             a.recycle();
         }
@@ -2534,6 +2534,15 @@ public class WeekView extends View {
         return this.mMinOverlappingMinutes;
     }
 
+    public boolean isScrollNumberOfVisibleDays() {
+        return this.mIsScrollNumberOfVisibleDays;
+    }
+
+    public void setScrollNumberOfVisibleDays(boolean scrollNumberOfVisibleDays) {
+        this.mIsScrollNumberOfVisibleDays = scrollNumberOfVisibleDays;
+        invalidate();
+    }
+
     /////////////////////////////////////////////////////////////////
     //
     //      Functions related to scrolling.
@@ -2566,9 +2575,9 @@ public class WeekView extends View {
         float beforeScroll = mStartOriginForScroll;
         boolean isPassed = false;
 
-        if (mDistanceDone > mDistanceMin || mDistanceDone < -mDistanceMin || !mScrollNumberOfVisibleDays) {
+        if (mDistanceDone > mDistanceMin || mDistanceDone < -mDistanceMin || !mIsScrollNumberOfVisibleDays) {
 
-            if (!mScrollNumberOfVisibleDays && mCurrentFlingDirection != Direction.NONE) {
+            if (!mIsScrollNumberOfVisibleDays && mCurrentFlingDirection != Direction.NONE) {
                 // snap to nearest day
                 leftDays = Math.round(leftDays);
             } else if (mCurrentScrollDirection == Direction.LEFT) {
@@ -2587,7 +2596,7 @@ public class WeekView extends View {
             }
 
 
-            if (mScrollNumberOfVisibleDays) {
+            if (mIsScrollNumberOfVisibleDays) {
                 boolean mayScrollHorizontal = beforeScroll - mStartOriginForScroll < getXMaxLimit() && mCurrentOrigin.x - mStartOriginForScroll > getXMinLimit();
                 if (isPassed && mayScrollHorizontal) {
                     // Stop current animation.

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -65,5 +65,6 @@
         <attr name="zoomFocusPoint" format="fraction" />
         <attr name="zoomFocusPointEnabled" format="boolean" />
         <attr name="dropListenerEnabled" format="boolean" />
+        <attr name="scrollNumberOfVisibleDays" format="boolean" />
     </declare-styleable>
 </resources>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -65,6 +65,6 @@
         <attr name="zoomFocusPoint" format="fraction" />
         <attr name="zoomFocusPointEnabled" format="boolean" />
         <attr name="dropListenerEnabled" format="boolean" />
-        <attr name="scrollNumberOfVisibleDays" format="boolean" />
+        <attr name="isScrollNumberOfVisibleDays" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This feature enable the scroll by the amount of days setted in NumberOfVisibleDays.

It's inspired by the work of SkyleKayma (pullrequest : #68) with some changes like the possibility to enable or not the scroll by the amount of days setted in NumberOfVisibleDays, ... and it's adapted to the last version of Week View library.