### PR TITLE
Fix ellipsize in drawEventTitle for text containing line breaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -19,5 +20,6 @@ allprojects {
 
     repositories {
         jcenter()
+        google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Aug 06 18:02:35 CEST 2017
+#Sat Feb 01 16:17:02 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,12 +5,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 28
     }
 }
 
@@ -18,8 +18,8 @@ configurations {
     javadocDeps
 }
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    javadocDeps 'com.android.support:appcompat-v7:25.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    javadocDeps 'com.android.support:appcompat-v7:28.0.0'
 }
 
 apply from: 'gradle-mvn-push.gradle'

--- a/library/src/main/java/com/alamkanak/weekview/WeekView.java
+++ b/library/src/main/java/com/alamkanak/weekview/WeekView.java
@@ -1006,7 +1006,7 @@ public class WeekView extends View {
                     pattern = "ww";
                     break;
                 default:
-                    pattern = "YYYY";
+                    pattern = "yyyy";
                     break;
             }
             Calendar firstVisibleDay = (Calendar) mHomeDate.clone();

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.alamkanak.weekview"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -20,8 +20,8 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':library')
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.squareup.retrofit:retrofit:1.9.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':library')
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.squareup.retrofit:retrofit:1.9.0'
 }

--- a/sample/src/main/java/com/alamkanak/weekview/sample/BasicActivity.java
+++ b/sample/src/main/java/com/alamkanak/weekview/sample/BasicActivity.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 
 import com.alamkanak.weekview.TextColorPicker;
+import com.alamkanak.weekview.WeekView;
 import com.alamkanak.weekview.WeekViewEvent;
 
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ public class BasicActivity extends BaseActivity {
                 return a < 0.2 ? Color.BLACK : Color.WHITE;
             }
         });
+        mWeekView.setAdditionalTimeInfo(WeekView.ADDITIONAL_INFO_MONTH);
     }
 
     @Override


### PR DESCRIPTION
Before the text was sometimes cut to late, when it contained manual linebreaks ("\n").
I fixed this by checking linewise if the text has to be ellipsized.